### PR TITLE
Fix empty string being parsed as empty embedded proto

### DIFF
--- a/src/ProtobufPart.js
+++ b/src/ProtobufPart.js
@@ -16,7 +16,7 @@ function ProtobufStringPart(props) {
   // TODO: Support repeated field
 
   const decoded = decodeProto(value);
-  if (decoded.leftOver.length === 0) {
+  if (value.length > 0 && decoded.leftOver.length === 0) {
     return <ProtobufDisplay value={decoded} />;
   } else {
     return value.toString();


### PR DESCRIPTION
An empty string is a valid protobuf message, but it's probably
not intended as one.

This normally should not happen since empty strings are not
encoded at all. However, BloomRPC encodes and includes it in
the message.

Example: 52 00