### PR TITLE
Decode varint as bigint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "react-dom": "^16.10.0",
     "react-scripts": "3.1.2",
     "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "^0.88.1",
-    "varint": "^5.0.0"
+    "semantic-ui-react": "^0.88.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/protobufDecoder.js
+++ b/src/protobufDecoder.js
@@ -1,4 +1,4 @@
-import varint from "varint";
+import { decodeVarint } from "./varintUtils";
 
 class BufferReader {
   constructor(buffer) {
@@ -7,10 +7,10 @@ class BufferReader {
   }
 
   readVarInt() {
-    const result = varint.decode(this.buffer, this.offset);
-    this.offset += varint.decode.bytes;
+    const result = decodeVarint(this.buffer, this.offset);
+    this.offset += result.length;
 
-    return result;
+    return result.value;
   }
 
   readBuffer(length) {
@@ -79,15 +79,15 @@ export function decodeProto(buffer) {
     while (reader.leftBytes() > 0) {
       reader.checkpoint();
 
-      const indexType = reader.readVarInt();
+      const indexType = parseInt(reader.readVarInt().toString());
       const type = indexType & 0b111;
       const index = indexType >> 3;
 
       let value;
       if (type === TYPES.VARINT) {
-        value = reader.readVarInt();
+        value = reader.readVarInt().toString();
       } else if (type === TYPES.STRING) {
-        const length = reader.readVarInt();
+        const length = parseInt(reader.readVarInt().toString());
         value = reader.readBuffer(length);
       } else if (type === TYPES.FIXED32) {
         value = reader.readBuffer(4);

--- a/src/protobufDecoder.test.js
+++ b/src/protobufDecoder.test.js
@@ -1,5 +1,6 @@
 import { decodeProto, TYPES } from "./protobufDecoder";
 import { parseHex } from "./hexUtils";
+import JSBI from "jsbi";
 
 it("decode empty protobuf", () => {
   const result = decodeProto(parseHex(""));
@@ -22,7 +23,7 @@ it("decode int", () => {
   expect(result.parts[0]).toEqual({
     index: 1,
     type: TYPES.VARINT,
-    value: 150
+    value: JSBI.BigInt(150)
   });
   expect(result.leftOver).toHaveLength(0);
 });
@@ -46,7 +47,7 @@ it("decode int and string", () => {
   expect(result.parts[0]).toEqual({
     index: 1,
     type: TYPES.VARINT,
-    value: 150
+    value: JSBI.BigInt(150)
   });
   expect(result.parts[1]).toEqual({
     index: 2,
@@ -87,7 +88,19 @@ it("decode int in gRPC", () => {
   expect(result.parts[0]).toEqual({
     index: 1,
     type: TYPES.VARINT,
-    value: 150
+    value: JSBI.BigInt(150)
+  });
+  expect(result.leftOver).toHaveLength(0);
+});
+
+it("decode int larger than maximum allowed by JavaScript", () => {
+  const result = decodeProto(parseHex("20FFFFFFFFFFFFFFFF7F"));
+
+  expect(result.parts).toHaveLength(1);
+  expect(result.parts[0]).toEqual({
+    index: 4,
+    type: TYPES.VARINT,
+    value: JSBI.BigInt("9223372036854775807")
   });
   expect(result.leftOver).toHaveLength(0);
 });

--- a/src/protobufDecoder.test.js
+++ b/src/protobufDecoder.test.js
@@ -23,7 +23,7 @@ it("decode int", () => {
   expect(result.parts[0]).toEqual({
     index: 1,
     type: TYPES.VARINT,
-    value: JSBI.BigInt(150)
+    value: "150"
   });
   expect(result.leftOver).toHaveLength(0);
 });
@@ -47,7 +47,7 @@ it("decode int and string", () => {
   expect(result.parts[0]).toEqual({
     index: 1,
     type: TYPES.VARINT,
-    value: JSBI.BigInt(150)
+    value: "150"
   });
   expect(result.parts[1]).toEqual({
     index: 2,
@@ -88,7 +88,7 @@ it("decode int in gRPC", () => {
   expect(result.parts[0]).toEqual({
     index: 1,
     type: TYPES.VARINT,
-    value: JSBI.BigInt(150)
+    value: "150"
   });
   expect(result.leftOver).toHaveLength(0);
 });
@@ -100,7 +100,7 @@ it("decode int larger than maximum allowed by JavaScript", () => {
   expect(result.parts[0]).toEqual({
     index: 4,
     type: TYPES.VARINT,
-    value: JSBI.BigInt("9223372036854775807")
+    value: "9223372036854775807"
   });
   expect(result.leftOver).toHaveLength(0);
 });

--- a/src/varintUtils.js
+++ b/src/varintUtils.js
@@ -1,0 +1,27 @@
+import JSBI from "jsbi";
+
+const BIGINT_2 = JSBI.BigInt(2);
+
+export function decodeVarint(buffer, offset) {
+  let res = JSBI.BigInt(0);
+  let shift = 0;
+  let byte = 0;
+
+  do {
+    if (offset >= buffer.length) {
+      throw new RangeError("Index out of bound decoding varint");
+    }
+
+    byte = buffer[offset++];
+
+    const multiplier = JSBI.exponentiate(BIGINT_2, JSBI.BigInt(shift));
+    const thisByteValue = JSBI.multiply(JSBI.BigInt(byte & 0x7f), multiplier);
+    shift += 7;
+    res = JSBI.add(res, thisByteValue);
+  } while (byte >= 0x80);
+
+  return {
+    value: res,
+    length: shift / 7
+  };
+}

--- a/src/varintUtils.test.js
+++ b/src/varintUtils.test.js
@@ -1,0 +1,27 @@
+import { decodeVarint } from "./varintUtils";
+import { parseHex } from "./hexUtils";
+import JSBI from "jsbi";
+
+describe("decodeVarint", () => {
+  it("should decode valid varint", () => {
+    const result = decodeVarint(parseHex("AC 02"), 0);
+    expect(result).toEqual({
+      value: JSBI.BigInt(300),
+      length: 2
+    });
+  });
+
+  it("should decode valid varint with offset", () => {
+    const result = decodeVarint(parseHex("AC 02"), 1);
+    expect(result).toEqual({
+      value: JSBI.BigInt(2),
+      length: 1
+    });
+  });
+
+  it("should throw error on invalid varint", () => {
+    expect(() => {
+      decodeVarint(parseHex("AC AC"), 1);
+    }).toThrow();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10286,11 +10286,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-varint@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.0.tgz#d826b89f7490732fabc0c0ed693ed475dcb29ebf"
-  integrity sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=
-
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
To support 64-bit integer which is larger than what
JS Number supports.

Fixes #9