### PR TITLE
Support interpreting varint values as signed (zig zag encoded)

### DIFF
--- a/src/ProtobufPart.js
+++ b/src/ProtobufPart.js
@@ -2,12 +2,32 @@ import React from "react";
 import { Table } from "semantic-ui-react";
 import { decodeProto, TYPES, typeToString } from "./protobufDecoder";
 import { decodeFixed32, decodeFixed64 } from "./protobufPartDecoder";
+import { interpretAsSignedType } from "./varintUtils";
+import JSBI from "jsbi";
 import ProtobufDisplay from "./ProtobufDisplay";
 
 function ProtobufVarintPart(props) {
   const { value } = props;
 
-  return value;
+  const asSigned = function(n) {
+    if (n) {
+      let asInt = JSBI.BigInt(n);
+      return (
+        "As signed (zig zag encoded): " +
+        interpretAsSignedType(asInt).toString()
+      );
+    } else {
+      return "";
+    }
+  };
+
+  return (
+    <span>
+      {value}
+      <br />
+      {asSigned(value)}
+    </span>
+  );
 }
 
 function ProtobufStringPart(props) {

--- a/src/varintUtils.js
+++ b/src/varintUtils.js
@@ -1,11 +1,22 @@
 import JSBI from "jsbi";
 
+const BIGINT_1 = JSBI.BigInt(1);
 const BIGINT_2 = JSBI.BigInt(2);
+
+export function interpretAsSignedType(n) {
+  // see https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/wire_format_lite.h#L857-L876
+  // TODO: does this handle sint64 as well?
+  return JSBI.bitwiseXor(
+    JSBI.signedRightShift(n, BIGINT_1),
+    JSBI.add(JSBI.bitwiseNot(JSBI.bitwiseAnd(n, BIGINT_1)), BIGINT_1)
+  );
+}
 
 export function decodeVarint(buffer, offset) {
   let res = JSBI.BigInt(0);
   let shift = 0;
   let byte = 0;
+  //let sint32Res = JSBI.BigInt(0);
 
   do {
     if (offset >= buffer.length) {
@@ -22,6 +33,7 @@ export function decodeVarint(buffer, offset) {
 
   return {
     value: res,
+    signedIntValue: interpretAsSignedType(res),
     length: shift / 7
   };
 }

--- a/src/varintUtils.test.js
+++ b/src/varintUtils.test.js
@@ -7,7 +7,17 @@ describe("decodeVarint", () => {
     const result = decodeVarint(parseInput("AC 02"), 0);
     expect(result).toEqual({
       value: JSBI.BigInt(300),
+      signedIntValue: JSBI.BigInt(150),
       length: 2
+    });
+  });
+
+  it("should decode valid varint with an sint32 possibility", () => {
+    const result = decodeVarint(parseInput("9F A3 64"), 0);
+    expect(result).toEqual({
+      value: JSBI.BigInt(1642911),
+      signedIntValue: JSBI.BigInt(-821456),
+      length: 3
     });
   });
 
@@ -15,6 +25,7 @@ describe("decodeVarint", () => {
     const result = decodeVarint(parseInput("AC 02"), 1);
     expect(result).toEqual({
       value: JSBI.BigInt(2),
+      signedIntValue: JSBI.BigInt(1),
       length: 1
     });
   });


### PR DESCRIPTION
Add new util function to translate unsigned value to signed

Add the signed value to the return from decodeVarint by calling fn

Add call to the new function from ProtobufVarintPart display code