### PR TITLE
Fix exception in some rare cases

### DIFF
--- a/src/protobufDecoder.js
+++ b/src/protobufDecoder.js
@@ -25,7 +25,7 @@ class BufferReader {
   trySkipGrpcHeader() {
     const backupOffset = this.offset;
 
-    if (this.buffer[this.offset] === 0) {
+    if (this.buffer[this.offset] === 0 && this.leftBytes() >= 5) {
       this.offset++;
       const length = this.buffer.readInt32BE(this.offset);
       this.offset += 4;


### PR DESCRIPTION
If there is a buffer that starts with 0 and is less than length 5, trySkipGrpcHeader will throw an exception at readInt32BE

Fixes #52